### PR TITLE
March 2025 patches

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 	"name": "PowerShell",
 	"image": "mcr.microsoft.com/powershell:lts-debian-11",
 	"features": {
-		"ghcr.io/devcontainers/features/common-utils:1": {
+		"ghcr.io/devcontainers/features/common-utils:2.5.2": {
 			"installZsh": "true",
 			"username": "vscode",
 			"uid": "1000",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 			"installOhMyZsh": "true",
 			"nonFreePackages": "true"
 		},
-		"ghcr.io/devcontainers/features/powershell:1": {}
+		"ghcr.io/devcontainers/features/powershell:1.5.0": {}
 	},
 
 	"postCreateCommand": "sudo chsh vscode -s \"$(which pwsh)\"",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
 		"ghcr.io/devcontainers/features/powershell:1.5.0": {}
 	},
 
-	"postCreateCommand": "sudo chsh vscode -s \"$(which pwsh)\"",
+	"postCreateCommand": "sudo apt-get update && sudo apt-get install -y powershell && sudo chsh vscode -s \"$(which pwsh)\"",
 
 	// Configure tool-specific properties.
 	"customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
 		"ghcr.io/devcontainers/features/powershell:1.5.0": {}
 	},
 
-	"postCreateCommand": "sudo apt-get update && sudo apt-get install -y powershell && sudo chsh vscode -s \"$(which pwsh)\"",
+	"postCreateCommand": "bash ./install.sh && sudo chsh vscode -s \"$(which pwsh)\"",
 
 	// Configure tool-specific properties.
 	"customizations": {

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+###################################
+# Prerequisites
+
+# Update the list of packages
+sudo apt-get update
+
+# Install pre-requisite packages.
+sudo apt-get install -y wget
+
+# Download the PowerShell package file
+wget https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/powershell_7.5.0-1.deb_amd64.deb
+
+###################################
+# Install the PowerShell package
+sudo dpkg -i powershell_7.5.0-1.deb_amd64.deb
+
+# Resolve missing dependencies and finish the install (if necessary)
+sudo apt-get install -f
+
+# Delete the downloaded package file
+rm powershell_7.5.0-1.deb_amd64.deb
+
+# Start PowerShell Preview
+pwsh

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The version of TFS or Azure DevOps Server can be found on the server itself by l
 
 ||Public version number|Semantic Version Number|Rest API Version|Release Date|Announcement URL|
 |-|-|-|-|-|-|
+||2022.2 Patch 4|19.235.35826.1|7.1|11-Mar-2025|https://devblogs.microsoft.com/devops/march-patches-for-azure-devops-server-3/|
 ||2022.2 Patch 3|19.235.35813.1|7.1|11-Feb-2025|https://devblogs.microsoft.com/devops/february-patches-for-azure-devops-server-4/|
 ||2022.2 Patch 2|19.235.35428.1|7.1|12-Nov-2024|https://devblogs.microsoft.com/devops/november-patches-for-azure-devops-server/|
 |❗|2022.2 Patch 1|19.235.35207.2|7.1|13-Aug-2024|Only use this on version 19.235.35102.1! - https://devblogs.microsoft.com/devops/june-patches-for-azure-devops-server-3/|
@@ -62,6 +63,7 @@ The version of TFS or Azure DevOps Server can be found on the server itself by l
 
 ||Public version number|Semantic Version Number|Rest API Version|Release Date|Announcement URL|
 |-|-|-|-|-|-|
+||2020.1.2 Patch 15|18.181.35826.2|6.0|11-Mar-2025|https://devblogs.microsoft.com/devops/march-patches-for-azure-devops-server-3/|
 ||2020.1.2 Patch 14|18.181.35425.2|6.0|12-Nov-2024|https://devblogs.microsoft.com/devops/november-patches-for-azure-devops-server/|
 ||2020.1.2 Patch 13|18.181.34705.3|6.0|12-Mar-2024|https://devblogs.microsoft.com/devops/march-patches-for-azure-devops-server-2/|
 ||2020.1.2 Patch 12|18.181.34526.2|6.0|13-Feb-2024|https://devblogs.microsoft.com/devops/february-patches-for-azure-devops-server-3/|
@@ -119,6 +121,7 @@ The version of TFS or Azure DevOps Server can be found on the server itself by l
 
 ||Public version number|Semantic Version Number|Rest API Version|Release Date|Announcement URL|
 |-|-|-|-|-|-|
+||2019.1.2 Patch 10|17.153.35826.3|5.0|11-Mar-2025|https://devblogs.microsoft.com/devops/march-patches-for-azure-devops-server-3/|
 ||2019.1.2 Patch 9|17.153.34812.2|5.0|28-May-2024|https://devblogs.microsoft.com/devops/may-patches-for-azure-devops-server-2/|
 ||2019.1.2 Patch 8|17.153.34706.1|5.0|12-Mar-2024|https://devblogs.microsoft.com/devops/march-patches-for-azure-devops-server-2/|
 ||2019.1.2 Patch 7|17.153.34526.6|5.0|13-Feb-2024|https://devblogs.microsoft.com/devops/february-patches-for-azure-devops-server-3/|

--- a/automation/get-versions.ps1
+++ b/automation/get-versions.ps1
@@ -15,10 +15,12 @@ if (!(Test-Path -Path $dataPath -PathType Container)) {
     New-Item -Path $dataPath -ItemType Directory
 }
 
-$response = Invoke-WebRequest -uri "https://devblogs.microsoft.com/devops/october-patches-for-azure-devops-server-3/"
+$response = Invoke-WebRequest -uri "https://devblogs.microsoft.com/devops/march-patches-for-azure-devops-server-3/"
 $downloadLinks = $response.Links | `
     Where-Object { $_.href -like "https://aka.ms/*" -and `
-                    (ConvertTo-Title -outerHTML $_.OuterHTML) -like "*Azure DevOps*" -and `
+                    ((ConvertTo-Title -outerHTML $_.OuterHTML) -like "*Azure DevOps*" `
+                        -or (ConvertTo-Title -outerHTML $_.OuterHTML) -like "*Patch*") `
+                     -and `
                     (ConvertTo-Title -outerHTML $_.OuterHTML) -notlike "*ISO*"  } | Group-Object -Property href | ForEach-Object { $_.Group[0] }
 foreach ($downloadLink in $downloadLinks) {
     $linkTitle = ConvertTo-Title -outerHTML $downloadLink.OuterHTML


### PR DESCRIPTION
This pull request includes several updates to the development container configuration, a new installation script and the patches of March 2025.

### Development Container Updates:
* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L7-R7): Updated the `common-utils` feature to version `2.5.2` and the `powershell` feature to version `1.5.0`. The `postCreateCommand` now includes running `install.sh` before changing the default shell to PowerShell (`pwsh`). [[1]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L7-R7) [[2]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L16-R19)

### New Installation Script:
* [`.devcontainer/install.sh`](diffhunk://#diff-209bdbb23aa0a35af49e0c18909203da30c00947c08b815d4c28852cf67084c8R1-R26): Added a new script to install PowerShell version `7.5.0` on the development container. The script handles downloading, installing, and cleaning up the installation package.

### Azure DevOps versions updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R33): Added entries for new patches released in March 2025 for Azure DevOps Server versions `2022.2`, `2020.1.2`, and `2019.1.2`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R33) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R66) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R124)

### Script Update:
* [`automation/get-versions.ps1`](diffhunk://#diff-1ccb30b6a4d4659a8a18bbc6d529c9583fab07f1fd815466a6d30cc016576540L18-R23): Updated the URL to fetch the latest patches for Azure DevOps Server from March 2025 and adjusted the filtering logic to include titles containing "Patch".